### PR TITLE
prevent PPO folder exist while resume training

### DIFF
--- a/nativerl/examples/train.sh
+++ b/nativerl/examples/train.sh
@@ -133,7 +133,7 @@ java ai.skymind.nativerl.RLlibHelper \
     $USER_LOG_PARAM \
     rllibtrain.py
 
-mkdir $OUTPUT_DIR/PPO
+mkdir -p $OUTPUT_DIR/PPO
 cp rllibtrain.py $OUTPUT_DIR/PPO
 
 set -e


### PR DESCRIPTION
this pr will prevent `mkdir: cannot create directory '/app/work/PPO': File exists` when the training is resumed