### PR TITLE
Add workaround to trigger all events at time 0.0 on Environment.reset()

### DIFF
--- a/nativerl/src/main/java/ai/skymind/nativerl/AnyLogicHelper.java
+++ b/nativerl/src/main/java/ai/skymind/nativerl/AnyLogicHelper.java
@@ -298,6 +298,10 @@ public class AnyLogicHelper {
             + resetSnippet
             + "\n"
             + "        engine.start(agent);\n"
+            + "        // Workaround to trigger all events at time 0.0\n"
+            + "        while (engine.getNextEventTime() == 0.0) {\n"
+            + "            engine.runFast(Math.ulp(0.0));\n"
+            + "        }\n"
             + "    }\n"
             + "\n"
             + (multiAgent


### PR DESCRIPTION
Fixes #61 

I don't currently have a model that I can test for it, but it should also fix #40. In any case, I've tested with the Traffic Phases example and it works fine, so it probably doesn't cause any undesired behavior.