### PR TITLE
Raise exception when not in multi-agent mode, but number of agents is not 1

### DIFF
--- a/nativerl/src/main/resources/ai/skymind/nativerl/RLlibHelper.py.hbs
+++ b/nativerl/src/main/resources/ai/skymind/nativerl/RLlibHelper.py.hbs
@@ -83,6 +83,8 @@ class {{classSimpleName environment}}({{#if multiAgent}}MultiAgentEnv{{else}}gym
             obsdict[str(i)] = obs
         return obsdict
 {{else}}
+        if self.nativeEnv.getNumberOfAgents() != 1:
+            raise ValueError("Not in multi-agent mode: Number of agents needs to be 1")
         obs = numpy.array(self.nativeEnv.getObservation())
         if isinstance(self.observation_space, gym.spaces.Dict):
             obs = {"action_mask": numpy.array(self.nativeEnv.getActionMask()), "real_obs": obs}
@@ -116,6 +118,8 @@ class {{classSimpleName environment}}({{#if multiAgent}}MultiAgentEnv{{else}}gym
         donedict['__all__'] = self.nativeEnv.isDone(-1)
         return obsdict, rewarddict, donedict, {}
 {{else}}
+        if self.nativeEnv.getNumberOfAgents() != 1:
+            raise ValueError("Not in multi-agent mode: Number of agents needs to be 1")
         if isinstance(self.action_space, gym.spaces.Tuple):
             actionArray = numpy.empty(shape=(0), dtype=numpy.float32)
             for j in range(0, len(action)):


### PR DESCRIPTION
Fixes #135

Manually tested that RLlib correctly fails with `ValueError: Not in multi-agent mode: Number of agents needs to be 1` when we're not using MultiAgentEnv, but we actually have multiple agents.