### PR TITLE
Add support for boolean variables to class processors

### DIFF
--- a/nativerl-policy/src/main/java/ai/skymind/nativerl/RewardProcessor.java
+++ b/nativerl-policy/src/main/java/ai/skymind/nativerl/RewardProcessor.java
@@ -69,7 +69,6 @@ public class RewardProcessor {
     }
     /** Returns {@code toDoubles(getRewardObject(agent, agentId))}. */
     public double[] getVariables(Object agent, int agentId) throws ReflectiveOperationException {
-        Object o = getRewardObject(agent, agentId);
         return toDoubles(getRewardObject(agent, agentId));
     }
 

--- a/nativerl-policy/src/main/java/ai/skymind/nativerl/util/Reflect.java
+++ b/nativerl-policy/src/main/java/ai/skymind/nativerl/util/Reflect.java
@@ -196,7 +196,11 @@ public class Reflect {
         Object[] objects = getFieldObjects(fields, object);
         double[] doubles = new double[objects.length];
         for (int i = 0; i < doubles.length; i++) {
-            doubles[i] = ((Number)objects[i]).doubleValue();
+            if (objects[i] instanceof Boolean) {
+                doubles[i] = ((Boolean)objects[i]) ? 1.0 : 0.0;
+            } else {
+                doubles[i] = ((Number)objects[i]).doubleValue();
+            }
         }
         return doubles;
     }
@@ -260,8 +264,12 @@ public class Reflect {
                         Array.setDouble(array, j, values != null ? values[i++] * (scale ? high[j] - low[j] : 1.0f) + (scale ? low[j] : 0.0f)
                                                                  : (high[j] - low[j]) * random.nextDouble() + low[j]);
                     }
+                } else if (c == boolean.class) {
+                    for (int j = 0; j < length; j++) {
+                        Array.setBoolean(array, j, values != null ? values[i++] != 0.0 : random.nextBoolean());
+                    }
                 } else {
-                    throw new IllegalArgumentException("Field " + f + " must be int, long, float, or double.");
+                    throw new IllegalArgumentException("Field " + f + " must be int, long, float, double, or boolean.");
                 }
             } else {
                 if (t == int.class) {
@@ -274,8 +282,10 @@ public class Reflect {
                 } else if (t == double.class) {
                     f.setDouble(object, values != null ? values[i++] * (scale ? high[0] - low[0] : 1.0f) + (scale ? low[0] : 0.0f)
                                                        : (high[0] - low[0]) * random.nextDouble() + low[0]);
+                } else if (t == boolean.class) {
+                    f.setBoolean(object, values != null ? values[i++] != 0.0 : random.nextBoolean());
                 } else {
-                    throw new IllegalArgumentException("Field " + f + " must be int, long, float, or double.");
+                    throw new IllegalArgumentException("Field " + f + " must be int, long, float, double, or boolean.");
                 }
             }
         }

--- a/nativerl-policy/src/test/java/ai/skymind/nativerl/RewardProcessorTest.java
+++ b/nativerl-policy/src/test/java/ai/skymind/nativerl/RewardProcessorTest.java
@@ -21,17 +21,19 @@ public class RewardProcessorTest {
     long data2 = 42;
     float data3 = 64;
     double[] data4 = {1, 2, 3, 4, 5};
+    boolean[] data5 = {true, false};
 
     class TestVariables {
         int var1 = data1;
         long var2 = data2;
         float var3 = data3;
         double[] var4 = data4;
+        boolean[] var5 = data5;
     }
 
     void rewardVariables(int agentId) {
         class DummyVariables extends TestVariables {
-            float var5 = agentId;
+            float var6 = agentId;
         }
     }
 
@@ -39,8 +41,8 @@ public class RewardProcessorTest {
         try {
             RewardProcessor rp = new RewardProcessor(this.getClass());
             assertEquals("DummyVariables", rp.getRewardClass().getSimpleName());
-            assertArrayEquals(new String[] {"var1", "var2", "var3", "var4[0]", "var4[1]", "var4[2]", "var4[3]", "var4[4]", "var5"}, rp.getVariableNames(this));
-            assertArrayEquals(new double[] {37, 42, 64, 1, 2, 3, 4, 5, 24}, rp.getVariables(this, 24), 0.0);
+            assertArrayEquals(new String[] {"var1", "var2", "var3", "var4[0]", "var4[1]", "var4[2]", "var4[3]", "var4[4]", "var5[0]", "var5[1]", "var6"}, rp.getVariableNames(this));
+            assertArrayEquals(new double[] {37, 42, 64, 1, 2, 3, 4, 5, 1, 0, 24}, rp.getVariables(this, 24), 0.0);
             TestVariables v = rp.getRewardObject(this, 24);
             assertEquals(37 + 42 + 64 + 5, new TestFunction().reward(v, v), 0.0);
         } catch (ReflectiveOperationException  ex) {


### PR DESCRIPTION
This works by mapping `true` to `1.0` and `false` to `0.0`, and the other way around to `!= 0.0`.
That makes it very straightforward to implement, and the fields themselves can be `boolean` for the reward editor.
@slinlee Please merge and it should be working right away for your models!