### PR TITLE
Use metricsSnippet for Environment.getMetrics() and update test()

### DIFF
--- a/nativerl/src/main/java/ai/skymind/nativerl/AbstractEnvironment.java
+++ b/nativerl/src/main/java/ai/skymind/nativerl/AbstractEnvironment.java
@@ -33,8 +33,7 @@ public abstract class AbstractEnvironment extends Environment {
     protected Array actionMask;
     /** The Array returned by the getObservation() method. */
     protected Array observation;
-    /** The Array returned by the step() method in the case of multiple agents. */
-    protected Array reward;
+    /** The Array returned by the getMetrics() method. */
     protected Array metrics;
 
     /** Initializes all (protected) fields based on discreteActions and continuousObservations. */
@@ -44,7 +43,6 @@ public abstract class AbstractEnvironment extends Environment {
         observationSpace = getContinuousSpace(continuousObservations);
         actionMask = new Array(new SSizeTVector().put(discreteActions));
         observation = new Array(new SSizeTVector().put(continuousObservations));
-        reward = null;
         metrics = null;
     }
 

--- a/nativerl/src/main/resources/ai/skymind/nativerl/AnyLogicHelper.java.hbs
+++ b/nativerl/src/main/resources/ai/skymind/nativerl/AnyLogicHelper.java.hbs
@@ -167,28 +167,40 @@ public class {{className}} extends AbstractEnvironment {
 
     @Override
     public Array getMetrics(long agentId) {
-        // TODO: This should be updated to use the metricsSnippet to allow customization by users
-        double[] lastMetrics = PathmindHelperRegistry.getHelper().rewardToDoubles(rewardAfter[(int)agentId]);
-
-        if (this.metrics == null || this.metrics.length() != lastMetrics.length) {
-            this.metrics = new Array(new SSizeTVector().put(lastMetrics.length));
+        double[] metrics = null;
+        {{{metricsSnippet}}}
+        if (metrics == null) {
+            metrics = PathmindHelperRegistry.getHelper().rewardToDoubles(rewardAfter[(int)agentId]);
         }
-        float[] array2 = new float[lastMetrics.length];
-        for (int i = 0; i < lastMetrics.length; i++) {
-            array2[i] = (float)lastMetrics[i];
+
+        if (this.metrics == null || this.metrics.length() != metrics.length) {
+            this.metrics = new Array(new SSizeTVector().put(metrics.length));
+        }
+        float[] array2 = new float[metrics.length];
+        for (int i = 0; i < metrics.length; i++) {
+            array2[i] = (float)metrics[i];
         }
         this.metrics.data().put(array2);
         return this.metrics;
     }
 
-    public double[] test() {
-        double[] metrics = null;
+    public double[][] test() {
+        int n = (int)getNumberOfAgents();
+        double[][] allMetrics = new double[n][];
         reset();
         while (!isDone(-1)) {
             engine.runFast();
         }
-        {{{metricsSnippet}}}
-        return metrics;
+        for (int i = 0; i < n; i++) {
+            double[] metrics = null;
+            {{{metricsSnippet}}}
+            if (metrics == null) {
+                rewardAfter[i] = PathmindHelperRegistry.getHelper().getRewardObject(i);
+                metrics = PathmindHelperRegistry.getHelper().rewardToDoubles(rewardAfter[i]);
+            }
+            allMetrics[i] = metrics;
+        }
+        return allMetrics;
     }
 
     public static void main(String[] args) throws Exception {
@@ -196,7 +208,7 @@ public class {{className}} extends AbstractEnvironment {
         {{~#if policyHelper}}
         {{className}} e = new {{className}}(PolicyHelper.load(new File(args[0])));
         for (int i = 0; i < {{testIterations}}; i++) {
-            lines.add(Arrays.toString(e.test()));
+            lines.add(Arrays.deepToString(e.test()));
         }
         {{~/if}}
         Files.write(Paths.get(args[0], "metrics.txt"), lines, Charset.defaultCharset());


### PR DESCRIPTION
Fixes #100

With these changes, the Environment will use the code snippet provided by users for the metrics, if available. If not, it fall backs on the current default of the reward variables, so nothing changes from the perspective of the web app, until the time when we decide to add support for custom metrics that is.

The nativerl-tests from pull #142 run fine and the custom metrics show up in RLlib's log.