### PR TITLE
dev-208 - MultiAgent metrics

### DIFF
--- a/PathmindPolicyHelper/PathmindPolicyHelper.alp
+++ b/PathmindPolicyHelper/PathmindPolicyHelper.alp
@@ -365,7 +365,7 @@ triggerNextAction();
 					<X>140</X><Y>70</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>false</PresentationFlag>
+					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties SaveInSnapshot="true" ModificatorType="STATIC">
 						<Type><![CDATA[int]]></Type>
@@ -605,7 +605,7 @@ class Actions {<br>
 					<X>140</X><Y>100</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>false</PresentationFlag>
+					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties SaveInSnapshot="true" ModificatorType="DYNAMIC">
 						<Type><![CDATA[boolean]]></Type>
@@ -702,7 +702,7 @@ class Actions {<br>
 					<X>20</X><Y>340</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>false</PresentationFlag>
+					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties SaveInSnapshot="true" ModificatorType="STATIC">
 						<Type><![CDATA[]]></Type>
@@ -782,7 +782,7 @@ https://help.pathmind.com/en/articles/3634254-4-triggering-actions
 					<X>570</X><Y>100</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>false</PresentationFlag>
+					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties TriggerType="timeout" Mode="cyclic">
 						<Timeout Class="CodeUnitValue">
@@ -943,11 +943,10 @@ if (!isTraining && steps == 1) {
 					<ReturnType><![CDATA[boolean]]></ReturnType>
 					<Id>1604359131653</Id>
 					<Name><![CDATA[isSkip]]></Name>
-					<Description><![CDATA[You may optionally trigger actions directly in your simulation. This could be triggered within a block, a state, an event, on startup of an agent, or anything else.]]></Description>
 					<X>140</X><Y>130</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
+					<PresentationFlag>false</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Parameter>
 						<Name><![CDATA[agentId]]></Name>


### PR DESCRIPTION
fix: https://github.com/SkymindIO/nativerl/issues/208

1. change `isSkip` parameter to `isSkipCondition` parameter so that PM helper UI keep the same.
![image](https://user-images.githubusercontent.com/7553831/97933288-282e8700-1d27-11eb-86cb-f4e790222dd8.png)


The way for Users to set `isSkip` condition will not be changed.
![Screenshot from 2020-11-02 16-11-54](https://user-images.githubusercontent.com/7553831/97933092-a3436d80-1d26-11eb-86f2-c5b2b424fd02.png)


2. create `isSkip` function to check skip condition with `isSkipCondition` and engine state.
The reason why I named it `isSkip` is to keep the same API call from NativeRL.
![image](https://user-images.githubusercontent.com/7553831/97933246-06cd9b00-1d27-11eb-91fd-24091c334868.png)

New helper for training is uploaded to
https://s3.console.aws.amazon.com/s3/upload/test-training-static-files.pathmind.com?region=us-east-1&prefix=pathmindhelper/1_3_0_dh/