### PR TITLE
support long obs

### DIFF
--- a/nativerl/src/main/java/ai/skymind/nativerl/AnyLogicHelper.java
+++ b/nativerl/src/main/java/ai/skymind/nativerl/AnyLogicHelper.java
@@ -17,7 +17,11 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -100,7 +104,7 @@ public class AnyLogicHelper {
     boolean isPLE;
 
     @Setter
-    List<String> setObs;
+    Map<String, List<String>> obsMap;
 
     public boolean getIsRLExperiment() {
         return isRLExperiment;
@@ -109,6 +113,8 @@ public class AnyLogicHelper {
     public boolean getIsPLE() {
         return isPLE;
     }
+
+    private static Pattern pattern = Pattern.compile("\\[[0-9]+\\];");
 
     /** Calls {@link #generateEnvironment()} and writes the result to a File. */
     public void generateEnvironment(File file) throws IOException, ReflectiveOperationException {
@@ -140,6 +146,7 @@ public class AnyLogicHelper {
 
         handlebars.registerHelpers(ConditionalHelpers.class);
         handlebars.registerHelper("escapePath", (context, options) -> ((File)context).getAbsolutePath().replace("\\", "/"));
+    handlebars.registerHelper("convertArray", (context, options) -> (context.toString()).replace("[", "{").replace("]", "}"));
         Template template = handlebars.compile("AnyLogicHelper.java");
 
         String env = template.apply(this);
@@ -149,7 +156,7 @@ public class AnyLogicHelper {
 
     /** Handle observation snippet, if the content is too long, it will split it into multiple methods. */
     public void setObservationSnippet() throws IOException {
-        this.setObs = new ArrayList<>();
+        this.obsMap = new LinkedHashMap<>();
         String obsSnippet = this.getObservationSnippet();
 
         if (obsSnippet.startsWith("file:")) {
@@ -162,16 +169,32 @@ public class AnyLogicHelper {
             List<String> lines = Files.lines(Paths.get(file.getPath()), Charset.defaultCharset())
                     .collect(Collectors.toList());
 
+            // add int idx = 0;
+            sb.append("int idx = 0; \n");
             // add double[] out = new double[n];
             sb.append(lines.remove(0) + "\n");
 
-            int limit = 3000;
-            int numObsSelection = lines.size() / limit + 1;
+            lines.forEach(l -> {
+                String[] split = l.split("in\\.");
+                Matcher matcher = pattern.matcher(split[1]);
+                String index = "-1";
+                String field;
+                if (matcher.find()) {
+                    String matched = matcher.group(0);
+                    index = matched.substring(1, matched.length() - 2);
+                    field = split[1].replace(matched, "");
+                } else {
+                    field = split[1].replace(";", "");
+                }
 
-            for (int i = 0; i < numObsSelection; i++) {
-                sb.append("setObs_" + i + "(out);\n");
-                setObs.add(String.join("\n", lines.subList((limit * i), Math.min(limit * (i+1), lines.size()))));
-            }
+                if (obsMap.containsKey(field)) {
+                    obsMap.get(field).add(index);
+                } else {
+                    List<String> indexes = new ArrayList<>();
+                    indexes.add(index);
+                    obsMap.put(field, indexes);
+                }
+            });
 
             this.observationSnippet = sb.toString();
         }

--- a/nativerl/src/main/resources/ai/skymind/nativerl/AnyLogicHelper.java.hbs
+++ b/nativerl/src/main/resources/ai/skymind/nativerl/AnyLogicHelper.java.hbs
@@ -306,7 +306,6 @@ class Training extends ExperimentCustom {
 {{/unless}}
 
 class PolicyObservationFilter implements ObservationFilter {
-    {{observationClassName}} in = null;
 
     // for some reason, the compiler fails if we try to use the name of inner classes more than once
     // so here we cast our objects using generics to work around this bug
@@ -315,17 +314,22 @@ class PolicyObservationFilter implements ObservationFilter {
     }
 
     public double[] filter(Object object) {
-        in = workAroundJavaBug(object);
+        {{observationClassName}} in = workAroundJavaBug(object);
         double[] out = null;
 
         {{{observationSnippet}}}
 
+        {{#each obsMap}}
+        {{#if (eq this.length 1)}}
+        out[idx++] = in.{{@key}};
+        {{else}}
+        int[] {{@key}} = {{{convertArray this}}};
+        for (int i = 0; i < {{@key}}.length; i++) {
+            out[idx++] = in.{{@key}}[{{@key}}[i]];
+        }
+        {{/if}}
+        {{/each}}
+
         return out;
     }
-
-    {{#each setObs}}
-    public void setObs_{{@index}}(double[] out) {
-        {{{this}}}
-    }
-    {{/each}}
 }


### PR DESCRIPTION
https://github.com/SkymindIO/nativerl/issues/250
with this pr, filter() will call setObs_n() to set selected observations.

```java
class PolicyObservationFilter implements ObservationFilter {
    Main$1Observations in = null;

    // for some reason, the compiler fails if we try to use the name of inner classes more than once
    // so here we cast our objects using generics to work around this bug
    public static <V> V workAroundJavaBug(Object o) {
        return (V)o;
    }

    public double[] filter(Object object) {
        in = workAroundJavaBug(object);
        double[] out = null;

        out = new double[7303];
setObs_0(out);
setObs_1(out);
        return out;
    }

 public void setObs_0(double[] out) {
        out[0] = in.offsetsX[0];
out[1] = in.offsetsX[1];
out[2] = in.offsetsX[2];
...
}

 public void setObs_1(double[] out) {
        out[3000] = in.offsetsX[0];
out[3001] = in.offsetsX[1];
...
}
```