### PR TITLE
write complete report after freezing

### DIFF
--- a/nativerl/python/run.py
+++ b/nativerl/python/run.py
@@ -173,11 +173,11 @@ def main(environment: str,
         queue_trials=True
     )
 
-    write_completion_report(trials=trials, output_dir=output_dir, algorithm=algorithm)
-
     if freezing:
         freeze_trained_policy(env=env_instance, env_name=env_name, callbacks=callbacks, trials=trials,
                               algorithm=algorithm, output_dir=f"{output_dir}/{algorithm}/freezing", is_discrete=discrete)
+
+    write_completion_report(trials=trials, output_dir=output_dir, algorithm=algorithm)
 
     ray.shutdown()
 


### PR DESCRIPTION
webapp rely on `ExperimentCompletionReport.txt` to get the status of the training.
https://github.com/SkymindIO/pathmind-webapp/blob/dev/pathmind-services/src/main/java/io/skymind/pathmind/services/training/cloud/aws/AWSExecutionProvider.java#L158

https://github.com/SkymindIO/pathmind-webapp/issues/2954

need to write the report after freezing.
freezing normally takes 4~6 mins depends on the model.