### PR TITLE
Dev-323 generate git.properties file during build process

### DIFF
--- a/nativerl/pom.xml
+++ b/nativerl/pom.xml
@@ -176,6 +176,25 @@
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.directory}/git.properties</generateGitPropertiesFilename>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/nativerl/src/main/assembly/bin.xml
+++ b/nativerl/src/main/assembly/bin.xml
@@ -29,6 +29,7 @@
         <include>*.dylib</include>
         <include>*.pyd</include>
         <include>*.so</include>
+        <include>git.properties</include>
       </includes>
       <excludes>
         <exclude>*-javadoc.jar</exclude>


### PR DESCRIPTION
resolves: https://github.com/SkymindIO/nativerl/issues/323

It will generate `git.properties` file that includes the information below.
```
#Generated by Git-Commit-Id-Plugin
#Mon May 03 22:28:08 UTC 2021
git.branch=ej_update_ray_config
git.build.host=c748cd7c77a8
git.build.time=2021-05-03T22\:28\:08+0000
git.build.user.email=
git.build.user.name=
git.build.version=1.6.0-SNAPSHOT
git.closest.tag.commit.count=
git.closest.tag.name=
git.commit.id.abbrev=f97cb79
git.commit.id.describe=f97cb79-dirty
git.commit.id.describe-short=f97cb79-dirty
git.commit.id.full=f97cb794d27f9655f32906efaaeb73544a5bc3e8
git.commit.message.full=Update Ray configuration\n\n- Support for 72 CPU cores\n- Checkpoint more frequently\n- Auto delete old checkpoints\n- Make convergence check start point configurable\n- Make max failures configurable
git.commit.message.short=Update Ray configuration
git.commit.time=2021-04-29T21\:26\:45+0000
git.commit.user.email=ejunprung@gmail.com
git.commit.user.name=ejunprung
git.dirty=true
git.local.branch.ahead=0
git.local.branch.behind=0
git.remote.origin.url=https\://github.com/SkymindIO/nativerl.git
git.tags=
git.total.commit.count=452
```
