### PR TITLE
WIP: Jd policy exports

### DIFF
--- a/nativerl/python/pathmind_training/callbacks.py
+++ b/nativerl/python/pathmind_training/callbacks.py
@@ -8,8 +8,6 @@ from ray.rllib.policy import Policy
 from ray.rllib.evaluation import MultiAgentEpisode, RolloutWorker
 from ray.rllib.agents.callbacks import DefaultCallbacks
 
-import ipdb
-
 from pathmind_training.exports import export_policy_from_checkpoint
 
 
@@ -53,7 +51,7 @@ def get_callbacks(debug_metrics, use_reward_terms, is_gym):
                     [w.apply.remote(lambda worker: worker.env.getMetrics()) for w in trainer.workers.remote_workers()])
 
                 env_config = trainer.config["env_config"]
-                if result["training_iteration"] % env_config["checkpoint_freq"] + 1 == 0 \
+                if result["training_iteration"] % (env_config["checkpoint_freq"] + 1) == 0 \
                              and result["training_iteration"] > 1:
                     experiment_dir = os.path.join(trainer.logdir, os.pardir)
                     export_policy_from_checkpoint(experiment_dir, trainer)

--- a/nativerl/python/pathmind_training/exports.py
+++ b/nativerl/python/pathmind_training/exports.py
@@ -1,14 +1,15 @@
+import os
+import shutil
+
 from ray.rllib.agents.ppo import PPOTrainer
 from ray.tune import Analysis
-
-import ipdb
 
 def export_policy_from_checkpoint(experiment_dir: str, trainer):
     analysis = Analysis(experiment_dir, default_metric="episode_reward_mean", default_mode="max")
     trial_logdir = analysis.get_best_logdir()
     checkpoint_path = analysis.get_best_checkpoint(trial_logdir)
-#    if checkpoint_path is None:
-#        ipdb.set_trace(context=20)
     trainer.restore(checkpoint_path)
-    export_dir = os.path.join(experiment_dir, checkpoint_path, os.pardir)
+    export_dir = os.path.join(trial_logdir, "model")
+    if os.path.exists(export_dir):
+        shutil.rmtree(export_dir)
     trainer.export_policy_model(export_dir)


### PR DESCRIPTION
Callbacks will generate an agent that, restored from the nearest checkpoint, and export to a the expected model format in each of the trials.