### PR TITLE
remove conflicting dependencies of Jackson

### DIFF
--- a/nativerl-analyzer/pom.xml
+++ b/nativerl-analyzer/pom.xml
@@ -81,11 +81,6 @@
             <artifactId>handlebars</artifactId>
             <version>4.2.0</version>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.10.1</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Fix 
```
Exception in thread "main" java.lang.NoSuchMethodError: com.fasterxml.jackson.core.JsonGenerator.writeStartArray(Ljava/lang/Object;I)V
        at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:78)
        at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:18)
        at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:727)
        at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:722)
```        

Spring Boot already has jackson-databind:2.10.0 as a transitive dependency. 
Apparently, there is some version clash when two versions are on the classpath. 