### PR TITLE
Fix Pathmind Simulation

### DIFF
--- a/nativerl/python/pathmind_training/environments.py
+++ b/nativerl/python/pathmind_training/environments.py
@@ -311,7 +311,7 @@ def get_native_env_from_simulation(simulation_name, observation_file=None, rewar
 
             # Flatten all observations here, e.g. [1, 2, [3, 4], 5] => [1, 2, 3, 4, 5]
             lists = [[obs_dict[obs]] if not isinstance(obs_dict[obs], typing.List) else obs_dict[obs]
-                     for obs in obs_names]
+                     for obs in self.obs_names]
             flat_obs = list(itertools.chain(*lists))
 
             return nativerl.Array(flat_obs)
@@ -349,5 +349,8 @@ def get_native_env_from_simulation(simulation_name, observation_file=None, rewar
         def getMetricsSpace(self) -> Continuous:
             num_metrics = len(self.getMetrics())
             return nativerl.Continuous(low=[-math.inf], high=[math.inf], shape=[num_metrics])
+
+        def getRewardTerms(self, agent_id: int = 0) -> np.array:
+                return NotImplemented
 
     return PathmindEnv()


### PR DESCRIPTION
I tested with Ed's model(added getRewardTerms() into Mdoe's Simulation.py)
[model_py_simulation.zip](https://github.com/SkymindIO/nativerl/files/7336534/model_py_simulation.zip)
```
curl -i -XPOST -H "X-PM-API-TOKEN: 11202253-5709-4eb7-9102-f87122314464" -F 'file=@/home/kepricon/Downloads/python_examples.zip' -F 'projectId=500' -F 'env=examples.mouse.single_agent_mouse_env.MouseAndCheese' -F 'start=TRUE' http://localhost:8081/py/upload
```

Here are Training results
![image](https://user-images.githubusercontent.com/7553831/137100312-e4d80460-bc03-49e4-b286-3aeae6bbcddc.png)

https://s3.console.aws.amazon.com/s3/buckets/dh-training-dynamic-files.pathmind.com?region=us-east-1&prefix=id3086/output/&showversions=false