### PR TITLE
provide pathmind simulation models' meta information

### DIFF
--- a/nativerl/python/pathmind_training/__init__.py
+++ b/nativerl/python/pathmind_training/__init__.py
@@ -2,4 +2,4 @@ from .environments import get_environment
 from .loggers import get_loggers
 from .scheduler import get_scheduler
 from .stopper import Stopper
-from .utils import modify_anylogic_db_properties, write_completion_report, write_file
+from .utils import modify_anylogic_db_properties, write_completion_report, write_file, write_temp_file

--- a/nativerl/python/pathmind_training/__init__.py
+++ b/nativerl/python/pathmind_training/__init__.py
@@ -3,3 +3,4 @@ from .loggers import get_loggers
 from .scheduler import get_scheduler
 from .stopper import Stopper
 from .utils import modify_anylogic_db_properties, write_completion_report, write_file, write_temp_file
+from .exceptions import ObservationMismatch

--- a/nativerl/python/pathmind_training/__init__.py
+++ b/nativerl/python/pathmind_training/__init__.py
@@ -3,4 +3,4 @@ from .loggers import get_loggers
 from .scheduler import get_scheduler
 from .stopper import Stopper
 from .utils import modify_anylogic_db_properties, write_completion_report, write_file, write_temp_file
-from .exceptions import ObservationMismatch
+from .exceptions import ObservationMismatch, ObservationFileNotFound

--- a/nativerl/python/pathmind_training/environments.py
+++ b/nativerl/python/pathmind_training/environments.py
@@ -341,6 +341,9 @@ def get_environment(
             if self.use_reward_terms:
                 return self.term_contributions
 
+        def write_meta(self):
+            return self.nativeEnv.writeMeta()
+
     # Set correct class name internally
     PathmindEnvironment.__name__ = simple_name
     PathmindEnvironment.__qualname__ = simple_name
@@ -453,5 +456,33 @@ def get_native_env_from_simulation(
         def getRewardTerms(self, agent_id: int = 0) -> nativerl.Array:
             reward_dict = self.simulation.get_reward(agent_id)
             return nativerl.Array(list(reward_dict.values()))
+
+        def writeMeta(self):
+            self.simulation.reset()
+            obs = self.simulation.get_observation(0)
+            obs_names = list(obs.keys())
+            obs_types = list(map(lambda i: type(i).__name__, list(obs.values())))
+
+            act = self.simulation.action_space(0)
+
+            rew = self.simulation.get_reward(0)
+            rew_names = list(rew.keys())
+            rew_types = list(map(lambda i: type(i).__name__, list(rew.values())))
+
+            agents = self.simulation.number_of_agents()
+            return {
+                "dto.setObservations": len(obs),
+                "dto.setObservationNames": obs_names,
+                "setObservationTypes": obs_types,
+                "setActions": act.choices,  # support continuous action space
+                "setActionMask": None,  # support action mask
+                "setRewardVariablesCount": len(rew),
+                "setRewardVariableNames": rew_names,
+                "setRewardVariableTypes": rew_types,
+                "setAgents": agents,
+                "setMode": "pm_single" if agents == 1 else "pm_multi",
+                "setEnabled": False
+            }
+
 
     return PathmindEnv()

--- a/nativerl/python/pathmind_training/environments.py
+++ b/nativerl/python/pathmind_training/environments.py
@@ -388,7 +388,7 @@ def get_native_env_from_simulation(
             # obs_full_names(local var): it has full obs list of simulation
             if obs:
                 obs_full_names = list(self.simulation.get_observation(0).keys())
-                diff_obs = set(obs_full_names) - set(obs)
+                diff_obs = set(obs) - set(obs_full_names)
                 if len(diff_obs) > 1:
                     raise ObservationMismatch(
                         f"Could not find {list(diff_obs)} observation(s) from the simulation. Make sure to check for obs.yaml and simulation"

--- a/nativerl/python/pathmind_training/environments.py
+++ b/nativerl/python/pathmind_training/environments.py
@@ -4,6 +4,7 @@ import math
 import os
 import typing
 from collections import OrderedDict
+import json
 
 import gym
 import numpy as np
@@ -342,7 +343,7 @@ def get_environment(
                 return self.term_contributions
 
         def write_meta(self):
-            return self.nativeEnv.writeMeta()
+            return json.dumps(self.nativeEnv.writeMeta())
 
     # Set correct class name internally
     PathmindEnvironment.__name__ = simple_name
@@ -471,17 +472,17 @@ def get_native_env_from_simulation(
 
             agents = self.simulation.number_of_agents()
             return {
-                "dto.setObservations": len(obs),
-                "dto.setObservationNames": obs_names,
-                "setObservationTypes": obs_types,
-                "setActions": act.choices,  # support continuous action space
-                "setActionMask": None,  # support action mask
-                "setRewardVariablesCount": len(rew),
-                "setRewardVariableNames": rew_names,
-                "setRewardVariableTypes": rew_types,
-                "setAgents": agents,
-                "setMode": "pm_single" if agents == 1 else "pm_multi",
-                "setEnabled": False
+                "observations": len(obs),
+                "observationNames": obs_names,
+                "observationTypes": obs_types,
+                "actions": act.choices,  # support continuous action space
+                "actionMask": False,  # support action mask
+                "rewardVariablesCount": len(rew),
+                "rewardVariableNames": rew_names,
+                "rewardVariableTypes": rew_types,
+                "agents": agents,
+                "mode": "pm_single" if agents == 1 else "pm_multi",
+                "enabled": False
             }
 
 

--- a/nativerl/python/pathmind_training/environments.py
+++ b/nativerl/python/pathmind_training/environments.py
@@ -12,7 +12,7 @@ import yaml
 from ray.rllib.env import MultiAgentEnv
 from ray.tune.registry import register_env
 
-from nativerl.python.pathmind_training import ObservationMismatch
+from pathmind_training.exceptions import ObservationMismatch, ObservationFileNotFound
 
 if os.environ.get("USE_PY_NATIVERL"):
     import pathmind_training.pynativerl as nativerl
@@ -367,9 +367,12 @@ def get_native_env_from_simulation(
 
     obs_names: typing.Optional[str] = None
     if observation_file:
-        with open(observation_file, "r") as f:
-            schema: OrderedDict = yaml.safe_load(f.read())
-            obs_names = schema.get("observations")
+        try:
+            with open(observation_file, "r") as f:
+                schema: OrderedDict = yaml.safe_load(f.read())
+                obs_names = schema.get("observations")
+        except FileNotFoundError as fe:
+            raise ObservationFileNotFound(f"obs.yaml file doesn't exist in {observation_file}")
 
     class PathmindEnv(nativerl.Environment):
         def __init__(

--- a/nativerl/python/pathmind_training/exceptions.py
+++ b/nativerl/python/pathmind_training/exceptions.py
@@ -1,9 +1,14 @@
 class ObservationMismatch(Exception):
-    """ Inappropriate argument value (of correct type). """
-    def __init__(self, *args, **kwargs): # real signature unknown
-        pass
+    def __init__(self, message):
+        self.message = message
 
-    @staticmethod # known case of __new__
-    def __new__(*args, **kwargs): # real signature unknown
-        """ Create and return a new object.  See help(type) for accurate signature. """
-        pass
+    def __str__(self):
+        return self.message
+
+
+class ObservationFileNotFound(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message

--- a/nativerl/python/pathmind_training/exceptions.py
+++ b/nativerl/python/pathmind_training/exceptions.py
@@ -1,0 +1,9 @@
+class ObservationMismatch(Exception):
+    """ Inappropriate argument value (of correct type). """
+    def __init__(self, *args, **kwargs): # real signature unknown
+        pass
+
+    @staticmethod # known case of __new__
+    def __new__(*args, **kwargs): # real signature unknown
+        """ Create and return a new object.  See help(type) for accurate signature. """
+        pass

--- a/nativerl/python/pathmind_training/utils.py
+++ b/nativerl/python/pathmind_training/utils.py
@@ -60,6 +60,14 @@ def write_completion_report(trials, output_dir, algorithm, best_freezing_log_dir
         )
         print("Training completed successfully")
 
+def write_temp_file(json):
+    import tempfile
+
+    new_file, file_name = tempfile.mkstemp()
+    with open(new_file, 'w') as f:
+        f.write(json)
+
+    return file_name
 
 def modify_anylogic_db_properties():
     # Make sure multiple processes can read the database from AnyLogic

--- a/nativerl/python/run.py
+++ b/nativerl/python/run.py
@@ -13,6 +13,7 @@ from pathmind_training import (
     get_scheduler,
     modify_anylogic_db_properties,
     write_completion_report,
+    write_temp_file,
 )
 from pathmind_training.callbacks import get_callback_function, get_callbacks
 from pathmind_training.environments import get_environment, get_gym_environment
@@ -313,8 +314,8 @@ def test(
         obs = env_instance.reset()
         mode = "pm_single" if len(obs) == 1 else "pm_multi"
         print(f"model-analyzer-mode:{mode}")
-        dto = env_instance.write_meta()
-        print(f"dto:{dto}")
+        dto_json = env_instance.write_meta()
+        print(f"DTOPath:{write_temp_file(dto_json)}")
 
     except Exception as e:
         print(

--- a/nativerl/python/run.py
+++ b/nativerl/python/run.py
@@ -310,8 +310,12 @@ def test(
         env_instance = env_creator(env_config=env_config)
         env_instance.__init__(env_config=env_config)
 
-        mode = "pm_single" if len(env_instance.reset()) == 1 else "pm_multi"
+        obs = env_instance.reset()
+        mode = "pm_single" if len(obs) == 1 else "pm_multi"
         print(f"model-analyzer-mode:{mode}")
+        dto = env_instance.write_meta()
+        print(f"dto:{dto}")
+
     except Exception as e:
         print(
             "cannot initiate Pathmind simulation env. it will try to initiate GYM env."

--- a/nativerl/python/run.py
+++ b/nativerl/python/run.py
@@ -8,7 +8,7 @@ import fire
 import numpy as np
 import ray
 
-from nativerl.python.pathmind_training import ObservationMismatch
+from pathmind_training import ObservationMismatch, ObservationFileNotFound
 from pathmind_training import (
     Stopper,
     get_loggers,
@@ -324,14 +324,19 @@ def test(
         dto_json = env_instance.write_meta()
         print(f"DTOPath:{write_temp_file(dto_json)}")
 
+    except ObservationFileNotFound as e:
+        print("obs.yaml doesn't exist.")
+        traceback.print_tb(e.__traceback__)
+        print(f"model-analyzer-error:{e}")
+        sys.exit(-1)
     except ObservationMismatch as e:
-        print("observation mismatch between full obs list and obs.yaml")
+        print("observation mismatch between full obs list and obs.yaml.")
         traceback.print_tb(e.__traceback__)
         print(f"model-analyzer-error:{e}")
         sys.exit(-1)
     except Exception as e:
         print(
-            "cannot initiate Pathmind simulation env. it will try to initiate GYM env."
+            f"cannot initiate Pathmind simulation env. it will try to initiate GYM env., {e}, {type(e)}"
         )
         traceback.print_tb(e.__traceback__)
         try:


### PR DESCRIPTION
We can get analyzed results for python models like AL models.

for example, we can see observation lists for python models from the webapp.
![image](https://user-images.githubusercontent.com/7553831/140666337-80d6bc9d-4e58-4389-8054-c61759f563cb.png)

- [x] validate selected obs 
- [x] check obs.yaml exist

### validate selected obs
[obs.yaml ](https://github.com/PathmindAI/pathmind-api/blob/main/tests/examples/mouse/obs.yaml)has 4 obs:   [`mouse_row`,  `mouse_col`, `mouse_row_dist`, `mouse_col_dist`]
but [`mouse_row_dist`, `mouse_col_dist`] doesn't belong to [full obs list](https://github.com/PathmindAI/pathmind-api/blob/main/tests/examples/mouse/mouse_env_pathmind.py#L41-L46).
```
kepricon@kepricon-G732LXS:~/git/pathmind-webapp/pathmind-api$ curl -i -XPOST -H "X-PM-API-TOKEN: 11202253-5709-4eb7-9102-f87122314464" -F 'file=@/home/kepricon/Downloads/python_examples/python_examples.zip' -F 'projectId=500' -F 'env=examples.mouse.mouse_env_pathmind.MouseAndCheese' -F 'obsSelection=examples/mouse/obs.yaml' -F 'start=TRUE' http://localhost:8081/py/upload
HTTP/1.1 100 

HTTP/1.1 400 
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
Location: http://localhost:8080/uploadModelError/Could%20not%20find%20%5B'mouse_row_dist',%20'mouse_col_dist'%5D%20observation(s)%20from%20the%20simulation.%20Make%20sure%20to%20check%20for%20obs.yaml%20and%20simulation
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: text/plain;charset=UTF-8
Content-Length: 134
Date: Fri, 12 Nov 2021 04:33:32 GMT
Connection: close

Could not find ['mouse_row_dist', 'mouse_col_dist'] observation(s) from the simulation. Make sure to check for obs.yaml and simulation
```

### check obs.yaml exist or not
-F 'obsSelection=examples/mouse/obs.yaml1'
```
kepricon@kepricon-G732LXS:~/git/pathmind-webapp/pathmind-api$ curl -i -XPOST -H "X-PM-API-TOKEN: 11202253-5709-4eb7-9102-f87122314464" -F 'file=@/home/kepricon/Downloads/python_examples/python_examples.zip' -F 'projectId=500' -F 'env=examples.mouse.mouse_env_pathmind.MouseAndCheese' **-F 'obsSelection=examples/mouse/obs.yaml1'** -F 'start=TRUE' http://localhost:8081/py/upload
HTTP/1.1 100 

HTTP/1.1 400 
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
Location: http://localhost:8080/uploadModelError/obs.yaml%20file%20doesn't%20exist%20in%20examples/mouse/obs.yaml1
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: text/plain;charset=UTF-8
Content-Length: 55
Date: Fri, 12 Nov 2021 01:55:27 GMT
Connection: close

obs.yaml file doesn't exist in examples/mouse/obs.yaml1
```