### PR TITLE
HOTFIX - Fix metrics bug

### DIFF
--- a/nativerl/python/pathmind_training/environments.py
+++ b/nativerl/python/pathmind_training/environments.py
@@ -321,12 +321,12 @@ def get_environment(
         def getMetrics(self):
             if is_multi_agent:
                 metrics_space = self.nativeEnv.getMetricsSpace()
+                metrics = np.zeros(metrics_space.shape)
                 for i in range(0, self.nativeEnv.getNumberOfAgents()):
                     if self.nativeEnv.isSkip(i):
                         agent_metrics = np.zeros(metrics_space.shape)
                     else:
                         agent_metrics = np.array(self.nativeEnv.getMetrics(i))
-                    metrics = np.zeros(metrics_space.shape)
                     metrics = (
                         agent_metrics if i == 0 else np.vstack((metrics, agent_metrics))
                     )


### PR DESCRIPTION
> there's a bad discrepancy in simulation metrics between NativeRL 1.8.0 --> 1.8.1
> - 1.8.0 --> https://app.pathmind.com/sharedExperiment/17922
> - 1.8.1 --> https://app.pathmind.com/sharedExperiment/
> in 1.8.1, the simulation metrics seem to be divided by 2. they are half what they should be

Introduced in #441. This was setting the metrics back to zero with each agent.
