### PR TITLE
Revert `bg_multi_mini` reward balancing changes

### DIFF
--- a/nativerl/python/pathmind_training/environments.py
+++ b/nativerl/python/pathmind_training/environments.py
@@ -277,15 +277,9 @@ def get_environment(
                 done_dict["__all__"] = all(done_dict.values())
 
                 if self.use_reward_terms and done_dict["__all__"]:
-                    max_array = np.zeros(len(reward_array), dtype=np.float32)
-                    for values in self.term_contributions_dict.values():
-                        max_array = np.array(
-                            [
-                                max(max_array[i], abs(values[i]))
-                                for i in range(len(reward_array))
-                            ]
-                        )
-                    self.term_contributions = max_array
+                    self.term_contributions += sum(
+                        self.term_contributions_dict.values()
+                    ) / len(self.term_contributions_dict)
                 return obs_dict, reward_dict, done_dict, {}
 
             else:


### PR DESCRIPTION
Including bg_multi_mini's reward balancing changes made training with reward functions perform worse: https://test.devpathmind.com/sharedExperiment/7273

And using reward terms trains, but also has poor results
https://test.devpathmind.com/sharedExperiment/7274

The throughputs are expected to be 60+ but they're in the 10-30s.
